### PR TITLE
Remote pool_config from runner module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,10 @@ module "runners" {
 
   # # Example of simple pool usages
   pool_runner_owner = "TheInternetBox"
-  pool_config = [{
-    size                = 5
-    schedule_expression = "cron(* * * * ? *)"
-  }]
+  // pool_config = [{
+  //   size                = 5
+  //   schedule_expression = "cron(* * * * ? *)"
+  // }]
 
   # configure your pre-built AMI
   # enabled_userdata = false


### PR DESCRIPTION
Apparently defining this will cause it to run and spin down spot containers every few hours, rather than ignoring this config. This was a $50 mistake that also caused AWS to flag my account. Didn't notice until I resolved the AWS flag and noticed a frequent instance request.